### PR TITLE
feat(subscriptions): implement CRUD and persistence

### DIFF
--- a/src/database/memory/migrations/0004_add_subscriptions.sql
+++ b/src/database/memory/migrations/0004_add_subscriptions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `subscriptions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`userId` text NOT NULL,
+	`contractCode` text NOT NULL,
+	`startDate` text NOT NULL,
+	`endDate` text,
+	`monthlyAmount` real NOT NULL,
+	`promoCode` text,
+	`status` text DEFAULT 'ACTIVE' NOT NULL
+);

--- a/src/database/memory/migrations/meta/_journal.json
+++ b/src/database/memory/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
             "when": 1768065200685,
             "tag": "0003_blushing_nextwave",
             "breakpoints": true
+        },
+        {
+            "idx": 4,
+            "version": "6",
+            "when": 1768294761307,
+            "tag": "0004_add_subscriptions",
+            "breakpoints": true
         }
     ]
 }

--- a/src/database/memory/schema.ts
+++ b/src/database/memory/schema.ts
@@ -1,5 +1,5 @@
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import { t_UserStatus } from '../../../api/models';
+import { sqliteTable, real, text } from 'drizzle-orm/sqlite-core';
+import { t_SubscriptionStatus, t_UserStatus } from '../../../api/models';
 
 export const users = sqliteTable('users', {
     id: text('id').primaryKey().notNull(),
@@ -23,4 +23,15 @@ export const admins = sqliteTable('admins', {
     lastLogin: text('lastLogin'),
     createdAt: text('createdAt'),
     updatedAt: text('updatedAt'),
+});
+
+export const subscriptions = sqliteTable('subscriptions', {
+    id: text('id').primaryKey().notNull(),
+    userId: text('userId').notNull(),
+    contractCode: text('contractCode').notNull(),
+    startDate: text('startDate').notNull(),
+    endDate: text('endDate'),
+    monthlyAmount: real('monthlyAmount').notNull(),
+    promoCode: text('promoCode'),
+    status: text('status').$type<t_SubscriptionStatus>().notNull().default('ACTIVE'),
 });

--- a/src/database/postgres/migrations/0001_add_subscriptions.sql
+++ b/src/database/postgres/migrations/0001_add_subscriptions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "subscriptions" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"userId" uuid NOT NULL,
+	"contractCode" varchar(255) NOT NULL,
+	"startDate" varchar(50) NOT NULL,
+	"endDate" varchar(50),
+	"monthlyAmount" real NOT NULL,
+	"promoCode" varchar(255),
+	"status" varchar(50) DEFAULT 'ACTIVE' NOT NULL
+);

--- a/src/database/postgres/migrations/meta/_journal.json
+++ b/src/database/postgres/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
             "when": 1768065127689,
             "tag": "0000_illegal_ego",
             "breakpoints": true
+        },
+        {
+            "idx": 1,
+            "version": "7",
+            "when": 1768294742269,
+            "tag": "0001_add_subscriptions",
+            "breakpoints": true
         }
     ]
 }

--- a/src/database/postgres/schema.ts
+++ b/src/database/postgres/schema.ts
@@ -1,5 +1,5 @@
-import { pgTable, text, varchar, timestamp, uuid } from 'drizzle-orm/pg-core';
-import { t_UserStatus } from '../../../api/models';
+import { pgTable, real, text, varchar, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { t_SubscriptionStatus, t_UserStatus } from '../../../api/models';
 
 export const users = pgTable('users', {
     id: uuid('id').primaryKey().notNull(),
@@ -23,4 +23,15 @@ export const admins = pgTable('admins', {
     lastLogin: timestamp('lastLogin'),
     createdAt: timestamp('createdAt').defaultNow(),
     updatedAt: timestamp('updatedAt').defaultNow(),
+});
+
+export const subscriptions = pgTable('subscriptions', {
+    id: uuid('id').primaryKey().notNull(),
+    userId: uuid('userId').notNull(),
+    contractCode: varchar('contractCode', { length: 255 }).notNull(),
+    startDate: varchar('startDate', { length: 50 }).notNull(),
+    endDate: varchar('endDate', { length: 50 }),
+    monthlyAmount: real('monthlyAmount').notNull(),
+    promoCode: varchar('promoCode', { length: 255 }),
+    status: varchar('status', { length: 50 }).$type<t_SubscriptionStatus>().notNull().default('ACTIVE'),
 });

--- a/src/handler/authenticated/subscription.ts
+++ b/src/handler/authenticated/subscription.ts
@@ -5,38 +5,153 @@ import type {
     UpdateSubscription,
     CancelSubscription,
 } from '../../../api/generated';
+import type { SubscriptionRepository } from '../../repository/subscription.repository';
+import type { UserPayload } from '../../utils/security';
+import { isAdmin } from '../../middleware/admin-guard';
 
-// GET /subscriptions
-export const listSubscriptions: ListSubscriptions = async (params, respond) => {
-    // TODO: Implement with database - filter by authenticated user
-    const notImplemented = { params, respond };
-    throw new Error(`Not implemented : ${notImplemented}`);
-};
+function getUserPayload(req: any): UserPayload | undefined {
+    return (req as any).user as UserPayload | undefined;
+}
 
-// POST /subscriptions
-export const createSubscription: CreateSubscription = async (params, respond) => {
-    // TODO: Implement with database
-    const notImplemented = { params, respond };
-    throw new Error(`Not implemented : ${notImplemented}`);
-};
+function hasAccessToSubscription(user: UserPayload | undefined, subscriptionUserId?: string) {
+    if (!user || !subscriptionUserId) {
+        return true;
+    }
 
-// GET /subscriptions/{subscriptionId}
-export const getSubscription: GetSubscription = async (params, respond) => {
-    // TODO: Implement with database
-    const notImplemented = { params, respond };
-    throw new Error(`Not implemented : ${notImplemented}`);
-};
+    if (user.userType === 'admin') {
+        return true;
+    }
 
-// PUT /subscriptions/{subscriptionId}
-export const updateSubscription: UpdateSubscription = async (params, respond) => {
-    // TODO: Implement with database
-    const notImplemented = { params, respond };
-    throw new Error(`Not implemented : ${notImplemented}`);
-};
+    return user.userId === subscriptionUserId;
+}
 
-// DELETE /subscriptions/{subscriptionId}
-export const cancelSubscription: CancelSubscription = async (params, respond) => {
-    // TODO: Implement with database
-    const notImplemented = { params, respond };
-    throw new Error(`Not implemented : ${notImplemented}`);
+export const createSubscriptionHandlers = (repository: SubscriptionRepository) => {
+    // GET /subscriptions
+    const listSubscriptions: ListSubscriptions = async (params, respond, req) => {
+        const user = getUserPayload(req);
+        const queryOptions = params.query ? { ...params.query } : {};
+
+        if (!isAdmin(req) && user?.userId) {
+            queryOptions.userId = user.userId;
+        }
+
+        const subscriptions = await repository.findAll(queryOptions);
+
+        return respond.with200().body({
+            success: true,
+            message: 'Subscriptions retrieved successfully',
+            payload: subscriptions,
+        });
+    };
+
+    // POST /subscriptions
+    const createSubscription: CreateSubscription = async (params, respond, req) => {
+        const user = getUserPayload(req);
+        const body = params.body;
+
+        const payload = {
+            ...body,
+            userId: !isAdmin(req) && user?.userId ? user.userId : body.userId,
+        };
+
+        const subscription = await repository.create(payload);
+
+        return respond.with201().body({
+            success: true,
+            message: 'Subscription created successfully',
+            payload: subscription,
+        });
+    };
+
+    // GET /subscriptions/{subscriptionId}
+    const getSubscription: GetSubscription = async (params, respond, req) => {
+        const { subscriptionId } = params.params;
+        const user = getUserPayload(req);
+
+        const subscription = await repository.findById(subscriptionId);
+
+        if (!subscription || !hasAccessToSubscription(user, subscription.userId)) {
+            return respond.with404().body({
+                success: false,
+                message: 'Subscription not found',
+                payload: null,
+            });
+        }
+
+        return respond.with200().body({
+            success: true,
+            message: 'Subscription retrieved successfully',
+            payload: subscription,
+        });
+    };
+
+    // PUT /subscriptions/{subscriptionId}
+    const updateSubscription: UpdateSubscription = async (params, respond, req) => {
+        const { subscriptionId } = params.params;
+        const user = getUserPayload(req);
+
+        const existing = await repository.findById(subscriptionId);
+        if (!existing || !hasAccessToSubscription(user, existing.userId)) {
+            return respond.with404().body({
+                success: false,
+                message: 'Subscription not found',
+                payload: null,
+            });
+        }
+
+        const updatedSubscription = await repository.update(subscriptionId, params.body);
+
+        if (!updatedSubscription) {
+            return respond.with404().body({
+                success: false,
+                message: 'Subscription not found',
+                payload: null,
+            });
+        }
+
+        return respond.with200().body({
+            success: true,
+            message: 'Subscription updated successfully',
+            payload: updatedSubscription,
+        });
+    };
+
+    // DELETE /subscriptions/{subscriptionId}
+    const cancelSubscription: CancelSubscription = async (params, respond, req) => {
+        const { subscriptionId } = params.params;
+        const user = getUserPayload(req);
+
+        const existing = await repository.findById(subscriptionId);
+        if (!existing || !hasAccessToSubscription(user, existing.userId)) {
+            return respond.with404().body({
+                success: false,
+                message: 'Subscription not found',
+                payload: null,
+            });
+        }
+
+        const cancelled = await repository.cancel(subscriptionId);
+
+        if (!cancelled) {
+            return respond.with404().body({
+                success: false,
+                message: 'Subscription not found',
+                payload: null,
+            });
+        }
+
+        return respond.with200().body({
+            success: true,
+            message: 'Subscription cancelled successfully',
+            payload: cancelled,
+        });
+    };
+
+    return {
+        listSubscriptions,
+        createSubscription,
+        getSubscription,
+        updateSubscription,
+        cancelSubscription,
+    };
 };

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -4,12 +4,15 @@ import { InMemoryUserRepository } from '../repository/memory/in-memory-user.repo
 import { PostgresUserRepository } from '../repository/postgres/postgres-user.repository';
 import { InMemoryAdminRepository } from '../repository/memory/in-memory-admin.repository';
 import { PostgresAdminRepository } from '../repository/postgres/postgres-admin.repository';
+import { InMemorySubscriptionRepository } from '../repository/memory/in-memory-subscription.repository';
+import { PostgresSubscriptionRepository } from '../repository/postgres/postgres-subscription.repository';
 import type { UserRepository } from '../repository/user.repository';
 import type { AdminRepository } from '../repository/admin.repository';
+import type { SubscriptionRepository } from '../repository/subscription.repository';
 import { getDatabase } from '../database/client';
 import { createAuthHandlers } from './public/auth';
 import { createRegistrationHandlers } from './public/registration';
-import * as subscriptions from './authenticated/subscription';
+import { createSubscriptionHandlers } from './authenticated/subscription';
 import { createUserHandlers } from './admin/user';
 import { createAdminAuthHandlers } from './admin/auth';
 import * as billing from './admin/billing';
@@ -18,19 +21,23 @@ import * as reports from './admin/report';
 const databaseInstance = getDatabase();
 let userRepository: UserRepository;
 let adminRepository: AdminRepository;
+let subscriptionRepository: SubscriptionRepository;
 
 if (DB_TYPE === 'postgres') {
     userRepository = new PostgresUserRepository(databaseInstance);
     adminRepository = new PostgresAdminRepository(databaseInstance);
+    subscriptionRepository = new PostgresSubscriptionRepository(databaseInstance);
 } else {
     userRepository = new InMemoryUserRepository(databaseInstance);
     adminRepository = new InMemoryAdminRepository(databaseInstance);
+    subscriptionRepository = new InMemorySubscriptionRepository(databaseInstance);
 }
 
 const authHandlers = createAuthHandlers(userRepository);
 const registrationHandlers = createRegistrationHandlers(userRepository);
 const userHandlers = createUserHandlers(userRepository);
 const adminAuthHandlers = createAdminAuthHandlers(adminRepository);
+const subscriptionHandlers = createSubscriptionHandlers(subscriptionRepository);
 
 export const handlers: Implementation = {
     // PUBLIC
@@ -39,11 +46,11 @@ export const handlers: Implementation = {
     createUser: registrationHandlers.createUser,
 
     // AUTHENTICATED USER
-    listSubscriptions: subscriptions.listSubscriptions,
-    createSubscription: subscriptions.createSubscription,
-    getSubscription: subscriptions.getSubscription,
-    updateSubscription: subscriptions.updateSubscription,
-    cancelSubscription: subscriptions.cancelSubscription,
+    listSubscriptions: subscriptionHandlers.listSubscriptions,
+    createSubscription: subscriptionHandlers.createSubscription,
+    getSubscription: subscriptionHandlers.getSubscription,
+    updateSubscription: subscriptionHandlers.updateSubscription,
+    cancelSubscription: subscriptionHandlers.cancelSubscription,
 
     // ADMIN
     listUsers: userHandlers.listUsers,

--- a/src/repository/memory/in-memory-subscription.repository.ts
+++ b/src/repository/memory/in-memory-subscription.repository.ts
@@ -1,0 +1,140 @@
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { and, eq } from 'drizzle-orm';
+import type { SubscriptionQueryOptions, SubscriptionRepository } from '../subscription.repository';
+import type {
+    t_CreateSubscriptionRequestBodySchema,
+    t_Subscription,
+    t_SubscriptionStatus,
+    t_UpdateSubscriptionRequestBodySchema,
+} from '../../../api/models';
+import { subscriptions } from '../../database/memory/schema';
+import { generateUUID } from '../../utils/uuid';
+
+const VALID_SUBSCRIPTION_STATUSES: t_SubscriptionStatus[] = ['ACTIVE', 'CANCELLED', 'PENDING_CANCEL'];
+
+export class InMemorySubscriptionRepository implements SubscriptionRepository {
+    constructor(private db: BetterSQLite3Database) {}
+
+    private toSubscription(row: any): t_Subscription {
+        return {
+            id: row.id,
+            userId: row.userId,
+            contractCode: row.contractCode,
+            startDate: row.startDate,
+            endDate: row.endDate ?? null,
+            monthlyAmount: row.monthlyAmount,
+            promoCode: row.promoCode ?? null,
+            status: row.status as t_SubscriptionStatus,
+        };
+    }
+
+    async findAll(options?: SubscriptionQueryOptions): Promise<t_Subscription[]> {
+        let query = this.db.select().from(subscriptions);
+        const conditions = [];
+
+        if (options?.userId) {
+            conditions.push(eq(subscriptions.userId, options.userId));
+        }
+
+        if (options?.status) {
+            conditions.push(eq(subscriptions.status, options.status));
+        }
+
+        if (conditions.length > 0) {
+            query = query.where(and(...conditions)) as any;
+        }
+
+        return query.all().map((row) => this.toSubscription(row));
+    }
+
+    async findById(id: string): Promise<t_Subscription | null> {
+        const rows = this.db.select().from(subscriptions).where(eq(subscriptions.id, id)).limit(1).all();
+        return rows[0] ? this.toSubscription(rows[0]) : null;
+    }
+
+    async create(data: t_CreateSubscriptionRequestBodySchema): Promise<t_Subscription> {
+        const subscription: t_Subscription = {
+            id: generateUUID(),
+            userId: data.userId,
+            contractCode: data.contractCode,
+            startDate: data.startDate,
+            endDate: null,
+            monthlyAmount: data.monthlyAmount,
+            promoCode: data.promoCode ?? null,
+            status: 'ACTIVE',
+        };
+
+        this.db
+            .insert(subscriptions)
+            .values({
+                id: subscription.id!,
+                userId: subscription.userId!,
+                contractCode: subscription.contractCode!,
+                startDate: subscription.startDate!,
+                endDate: subscription.endDate,
+                monthlyAmount: subscription.monthlyAmount!,
+                promoCode: subscription.promoCode,
+                status: subscription.status!,
+            })
+            .run();
+
+        return subscription;
+    }
+
+    async update(id: string, data: t_UpdateSubscriptionRequestBodySchema): Promise<t_Subscription | null> {
+        const existing = await this.findById(id);
+        if (!existing) {
+            return null;
+        }
+
+        if (data.status && !VALID_SUBSCRIPTION_STATUSES.includes(data.status)) {
+            throw new Error(`Invalid subscription status: ${data.status}`);
+        }
+
+        const updated: t_Subscription = {
+            ...existing,
+            endDate: data.endDate !== undefined ? data.endDate : existing.endDate,
+            monthlyAmount: data.monthlyAmount ?? existing.monthlyAmount,
+            promoCode: data.promoCode !== undefined ? data.promoCode : existing.promoCode,
+            status: data.status ?? existing.status,
+        };
+
+        this.db
+            .update(subscriptions)
+            .set({
+                endDate: updated.endDate,
+                monthlyAmount: updated.monthlyAmount,
+                promoCode: updated.promoCode,
+                status: updated.status,
+            })
+            .where(eq(subscriptions.id, id))
+            .run();
+
+        return updated;
+    }
+
+    async cancel(id: string): Promise<t_Subscription | null> {
+        const existing = await this.findById(id);
+        if (!existing) {
+            return null;
+        }
+
+        const endDate = existing.endDate ?? new Date().toISOString().slice(0, 10);
+        const updated: t_Subscription = {
+            ...existing,
+            endDate,
+            status: 'CANCELLED',
+        };
+
+        this.db
+            .update(subscriptions)
+            .set({
+                endDate: updated.endDate,
+                status: updated.status,
+            })
+            .where(eq(subscriptions.id, id))
+            .run();
+
+        return updated;
+    }
+}

--- a/src/repository/postgres/postgres-subscription.repository.ts
+++ b/src/repository/postgres/postgres-subscription.repository.ts
@@ -1,0 +1,140 @@
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { and, eq } from 'drizzle-orm';
+import type { SubscriptionQueryOptions, SubscriptionRepository } from '../subscription.repository';
+import type {
+    t_CreateSubscriptionRequestBodySchema,
+    t_Subscription,
+    t_SubscriptionStatus,
+    t_UpdateSubscriptionRequestBodySchema,
+} from '../../../api/models';
+import { subscriptions } from '../../database/postgres/schema';
+import { generateUUID } from '../../utils/uuid';
+
+const VALID_SUBSCRIPTION_STATUSES: t_SubscriptionStatus[] = ['ACTIVE', 'CANCELLED', 'PENDING_CANCEL'];
+
+export class PostgresSubscriptionRepository implements SubscriptionRepository {
+    constructor(private db: NodePgDatabase) {}
+
+    private toSubscription(row: typeof subscriptions.$inferSelect): t_Subscription {
+        return {
+            id: row.id,
+            userId: row.userId,
+            contractCode: row.contractCode,
+            startDate: row.startDate,
+            endDate: row.endDate ?? null,
+            monthlyAmount: row.monthlyAmount,
+            promoCode: row.promoCode ?? null,
+            status: row.status as t_SubscriptionStatus,
+        };
+    }
+
+    async findAll(options?: SubscriptionQueryOptions): Promise<t_Subscription[]> {
+        let query = this.db.select().from(subscriptions);
+        const conditions = [];
+
+        if (options?.userId) {
+            conditions.push(eq(subscriptions.userId, options.userId));
+        }
+
+        if (options?.status) {
+            conditions.push(eq(subscriptions.status, options.status));
+        }
+
+        if (conditions.length > 0) {
+            query = query.where(and(...conditions)) as any;
+        }
+
+        const rows = await query.execute();
+        return rows.map((row) => this.toSubscription(row));
+    }
+
+    async findById(id: string): Promise<t_Subscription | null> {
+        const rows = await this.db.select().from(subscriptions).where(eq(subscriptions.id, id)).limit(1).execute();
+        return rows[0] ? this.toSubscription(rows[0]) : null;
+    }
+
+    async create(data: t_CreateSubscriptionRequestBodySchema): Promise<t_Subscription> {
+        const id = generateUUID();
+
+        const [inserted] = await this.db
+            .insert(subscriptions)
+            .values({
+                id,
+                userId: data.userId,
+                contractCode: data.contractCode,
+                startDate: data.startDate,
+                endDate: null,
+                monthlyAmount: data.monthlyAmount,
+                promoCode: data.promoCode ?? null,
+                status: 'ACTIVE',
+            })
+            .returning();
+
+        if (!inserted) {
+            throw new Error('Failed to create subscription');
+        }
+
+        return this.toSubscription(inserted);
+    }
+
+    async update(id: string, data: t_UpdateSubscriptionRequestBodySchema): Promise<t_Subscription | null> {
+        const existing = await this.findById(id);
+        if (!existing) {
+            return null;
+        }
+
+        if (data.status && !VALID_SUBSCRIPTION_STATUSES.includes(data.status)) {
+            throw new Error(`Invalid subscription status: ${data.status}`);
+        }
+
+        const updateData: Partial<typeof subscriptions.$inferInsert> = {};
+
+        if (data.endDate !== undefined) {
+            updateData.endDate = data.endDate;
+        }
+
+        if (data.monthlyAmount !== undefined) {
+            updateData.monthlyAmount = data.monthlyAmount;
+        }
+
+        if (data.promoCode !== undefined) {
+            updateData.promoCode = data.promoCode;
+        }
+
+        if (data.status !== undefined) {
+            updateData.status = data.status;
+        }
+
+        if (Object.keys(updateData).length === 0) {
+            return existing;
+        }
+
+        const [updated] = await this.db
+            .update(subscriptions)
+            .set(updateData)
+            .where(eq(subscriptions.id, id))
+            .returning();
+
+        return updated ? this.toSubscription(updated) : null;
+    }
+
+    async cancel(id: string): Promise<t_Subscription | null> {
+        const existing = await this.findById(id);
+        if (!existing) {
+            return null;
+        }
+
+        const endDate = existing.endDate ?? new Date().toISOString().slice(0, 10);
+
+        const [updated] = await this.db
+            .update(subscriptions)
+            .set({
+                endDate,
+                status: 'CANCELLED',
+            })
+            .where(eq(subscriptions.id, id))
+            .returning();
+
+        return updated ? this.toSubscription(updated) : null;
+    }
+}

--- a/src/repository/subscription.repository.ts
+++ b/src/repository/subscription.repository.ts
@@ -1,0 +1,23 @@
+import type {
+    t_CreateSubscriptionRequestBodySchema,
+    t_Subscription,
+    t_SubscriptionStatus,
+    t_UpdateSubscriptionRequestBodySchema,
+} from '../../api/models';
+
+export interface SubscriptionQueryOptions {
+    userId?: string;
+    status?: t_SubscriptionStatus;
+}
+
+export interface SubscriptionRepository {
+    findAll(options?: SubscriptionQueryOptions): Promise<t_Subscription[]>;
+
+    findById(id: string): Promise<t_Subscription | null>;
+
+    create(data: t_CreateSubscriptionRequestBodySchema): Promise<t_Subscription>;
+
+    update(id: string, data: t_UpdateSubscriptionRequestBodySchema): Promise<t_Subscription | null>;
+
+    cancel(id: string): Promise<t_Subscription | null>;
+}


### PR DESCRIPTION
## Summary
- add subscriptions repository (memory + postgres)
- add subscriptions table schema + migrations
- implement subscriptions handlers and wiring

## Testing
- npm test
- manual swagger check (subscriptions CRUD)